### PR TITLE
Allow blacklisting links in urdf robot model

### DIFF
--- a/differentiable_robot_model/robot_model.py
+++ b/differentiable_robot_model/robot_model.py
@@ -5,7 +5,7 @@ Differentiable robot model class
 TODO
 """
 
-from typing import List, Tuple, Dict, Optional
+from typing import List, Tuple, Dict, Optional, Set
 import os
 
 import torch
@@ -52,7 +52,9 @@ class DifferentiableRobotModel(torch.nn.Module):
     TODO
     """
 
-    def __init__(self, urdf_path: str, name="", device=None):
+    def __init__(
+        self, urdf_path: str, name="", links_blacklist: Set[str] = None, device=None
+    ):
 
         super().__init__()
 
@@ -62,7 +64,9 @@ class DifferentiableRobotModel(torch.nn.Module):
             torch.device(device) if device is not None else torch.device("cpu")
         )
 
-        self._urdf_model = URDFRobotModel(urdf_path=urdf_path, device=self._device)
+        self._urdf_model = URDFRobotModel(
+            urdf_path=urdf_path, links_blacklist=links_blacklist, device=self._device
+        )
         self._bodies = torch.nn.ModuleList()
         self._n_dofs = 0
         self._controlled_joints = []
@@ -72,7 +76,7 @@ class DifferentiableRobotModel(torch.nn.Module):
         # joint is at the beginning of a link
         self._name_to_idx_map = dict()
 
-        for (i, link) in enumerate(self._urdf_model.robot.links):
+        for (i, link) in enumerate(self._urdf_model.links):
 
             rigid_body_params = self._urdf_model.get_body_parameters_from_urdf(i, link)
 

--- a/tests/test_urdf_robot.py
+++ b/tests/test_urdf_robot.py
@@ -1,0 +1,170 @@
+from unittest import mock
+
+import pytest
+import torch
+
+from differentiable_robot_model.robot_model import DifferentiableRobotModel
+
+# this file contains no dummy link
+urdf_clean_file = r"""
+<robot name="test_robot">
+    <link name="link_base"/>
+    <joint name="joint_1" type="continuous">
+        <parent link="link_base"/>
+        <child link="link_1"/>
+        <axis xyz="0 0 1"/>
+        <limit effort="40" lower="-6.28" upper="6.28" velocity="0.628"/>
+        <origin rpy="0 3.14 0" xyz="0 0 0.15675"/>
+    </joint>
+    <link name="link_1">
+        <inertial>
+            <mass value="1.0"/>
+            <origin xyz="0 0 -0.06"/>
+            <inertia ixx="0.00034" ixy="0" ixz="0" iyy="0.00034" iyz="0" izz="0.00058"/>
+        </inertial>
+    </link>
+</robot>
+"""
+
+# this file contains one dummy link at the beginning
+urdf_with_dummy_link = r"""
+<robot name="test_robot">
+    <link name="link_base"/>
+    <link name="dummy_link"/>
+    <joint name="joint_1" type="continuous">
+        <parent link="link_base"/>
+        <child link="link_1"/>
+        <axis xyz="0 0 1"/>
+        <limit effort="40" lower="-6.28" upper="6.28" velocity="0.628"/>
+        <origin rpy="0 3.14 0" xyz="0 0 0.15675"/>
+    </joint>
+    <link name="link_1">
+        <inertial>
+            <mass value="1.0"/>
+            <origin xyz="0 0 -0.06"/>
+            <inertia ixx="0.00034" ixy="0" ixz="0" iyy="0.00034" iyz="0" izz="0.00058"/>
+        </inertial>
+    </link>
+</robot>
+"""
+
+# this file contains one dummy link (the end_effector frame) between arm and finger
+urdf_link1_eff_finger1 = r"""
+<robot name="test_robot">
+    <link name="link_base">
+        <inertial>
+            <mass value="0.5"/>
+            <origin rpy="0 0 0" xyz="0 0 0.1255"/>
+            <inertia ixx="0.0009" ixy="0" ixz="0" iyy="0.0009" iyz="0" izz="0.0003"/>
+        </inertial>
+    </link>
+    <joint name="joint_1" type="continuous">
+        <parent link="link_base"/>
+        <child link="link_1"/>
+        <axis xyz="0 0 1"/>
+        <limit effort="40" lower="-6.28" upper="6.28" velocity="0.628"/>
+        <origin rpy="0 3.14 0" xyz="0 0 0.15675"/>
+    </joint>
+    <link name="link_1">
+        <inertial>
+            <mass value="1.0"/>
+            <origin xyz="0 0 -0.06"/>
+            <inertia ixx="0.00034" ixy="0" ixz="0" iyy="0.00034" iyz="0" izz="0.00058"/>
+        </inertial>
+    </link>
+    <link name="end_effector"/>
+    <joint name="joint_end_effector" type="fixed">
+        <parent link="link_1"/>
+        <child link="end_effector"/>
+        <axis xyz="0 0 0"/>
+        <limit effort="2000" lower="0" upper="0" velocity="1"/>
+        <origin rpy="3.14 0 1.57" xyz="0 0 -0.1600"/>
+    </joint>
+    <link name="link_finger_1">
+        <inertial>
+            <mass value="0.01"/>
+            <origin xyz="0.022 0 0"/>
+            <inertia ixx="7.89e-07" ixy="0" ixz="0" iyy="7.89e-07" iyz="0" izz="8e-08"/>
+        </inertial>
+    </link>
+    <joint name="joint_finger_1" type="revolute">
+        <parent link="link_1"/>
+        <child link="link_finger_1"/>
+        <axis xyz="0 0 1"/>
+        <origin rpy="-1.57 .64 1.35" xyz="0.0027 0.031 -0.114"/>
+        <limit effort="2" lower="0" upper="1.51" velocity="1"/>
+    </joint>
+</robot>
+"""
+
+
+def build_robot_model(links_blacklist, file_content):
+    with mock.patch("builtins.open", mock.mock_open(read_data=file_content)):
+        robot_model = DifferentiableRobotModel(
+            "mocked_file.urdf", "test", links_blacklist=links_blacklist,
+        )
+    return robot_model
+
+
+@pytest.fixture
+def robot_model(request):
+    return build_robot_model(*request.param)
+
+
+@pytest.mark.filterwarnings("ignore:Intermediate link")
+@pytest.mark.parametrize(
+    "robot_model",
+    [(set(), urdf_link1_eff_finger1), ({"foobar"}, urdf_link1_eff_finger1)],
+    indirect=["robot_model"],
+)
+def test_exception(robot_model):
+    with pytest.raises(TypeError):
+        rand_qs = torch.rand(1, 2)
+        # TypeError: unsupported operand type(s) for *: 'NoneType' and 'NoneType
+        robot_model.compute_forward_dynamics(q=rand_qs, qd=rand_qs, f=rand_qs)
+
+
+@pytest.mark.parametrize(
+    "links_blacklist, file_content",
+    [
+        (set(), urdf_link1_eff_finger1),
+        ({"foobar"}, urdf_link1_eff_finger1),
+        (set(), urdf_with_dummy_link),
+        ({"foobar"}, urdf_with_dummy_link),
+    ],
+)
+def test_emit_warnings(links_blacklist, file_content):
+    # assert a warning is emitted
+    with pytest.warns(UserWarning):
+        build_robot_model(links_blacklist, file_content)
+
+
+@pytest.mark.parametrize(
+    "robot_model",
+    [
+        ({"end_effector"}, urdf_link1_eff_finger1),
+        ({"dummy_link"}, urdf_with_dummy_link),
+        (set(), urdf_clean_file),
+    ],
+    indirect=["robot_model"],
+)
+def test_no_exception_with_correct_blacklist(robot_model):
+    rand_qs = torch.rand(1, len(robot_model.get_link_names()) - 1)
+    robot_model.compute_forward_dynamics(q=rand_qs, qd=rand_qs, f=rand_qs)
+
+
+@pytest.mark.parametrize(
+    "links_blacklist, file_content",
+    [
+        ({"end_effector"}, urdf_link1_eff_finger1),
+        ({"dummy_link"}, urdf_with_dummy_link),
+        (set(), urdf_clean_file),
+    ],
+)
+def test_no_emit_warnings(links_blacklist, file_content):
+    with pytest.warns(None) as record:
+        # assert no warning after using correct links blacklist
+        build_robot_model(links_blacklist, file_content)
+        assert (
+            len(record) == 0
+        ), f"Warnings should not be emitted. {[r.message for r in record]}"


### PR DESCRIPTION
This PR allows user to blacklist certain links when creating `DifferentiableRobotModel`.

## Motivating example
Consider the [urf file](https://gist.github.com/soraxas/03588e631b5f349b4d29402dfee4cb5e) created directly from the `.xacro` file for the [Kinova Jaco Arm](https://github.com/Kinovarobotics/kinova-ros).

Currently, if we were to create a `DifferentiableRobotModel` from the `urdf` file and try to compute forward dynamic, it will result in
```sh
...
...
no dynamics information for link: root
no dynamics information for link: world
no dynamics information for link: j2n6s300_end_effector
Traceback (most recent call last):
  File "my_file.py", line 142, in <module>
    run()
  File "learn_forward_dynamics_iiwa.py", line 112, in run
    robot_model.compute_forward_dynamics(q=rand, qd=rand, f=rand)
  File "/home/soraxas/${SOME_PATH}/site-packages/differentiable_robot_model/robot_model.py", line 43, in wrapper
    return function(self, *args, **kwargs)
  File "/home/soraxas/${SOME_PATH}/site-packages/differentiable_robot_model/robot_model.py", line 460, in compute_forward_dynamics
    icxvel = body.inertia.multiply_motion_vec(body.vel)
  File "/home/soraxas/${SOME_PATH}/site-packages/differentiable_robot_model/spatial_vector_algebra.py", line 331, in multiply_motion_vec
    mcom = com * mass
TypeError: unsupported operand type(s) for *: 'NoneType' and 'NoneType'```
```

The reason is that Kinova contains an intermediate dummy link (i.e. `j2n6s300_end_effector` in this case) to denotes a special coordinate frame, that **contains no inertial values**. However, `differentiable-robot-model` tries to compute forward kinematics with the said link.


## Changes in this PR

### Without blacklist

Running the same code directly

```python
robot_model = DifferentiableRobotModel(urdf_path, "jaco", device=device)
```

the URDF model will now generates **warnings** to suggest user to add links to blacklist

```sh
/home/soraxas/${SOME_PATH}/site-packages/differentiable_robot_model/urdf_utils.py:125: 
  UserWarning: Intermediate link 1 'world' contains no dynamic information. 
  Consider adding it to `links_blacklist` if this is a dummy link to remove it from kinematic chain.

/home/soraxas/${SOME_PATH}/site-packages/differentiable_robot_model/urdf_utils.py:125: 
  UserWarning: Intermediate link 9 'j2n6s300_end_effector' contains no dynamic information. 
  Consider adding it to `links_blacklist` if this is a dummy link to remove it from kinematic chain.
```
... and if you subsequently try to compute forward kinematic it will still crash

```python
robot_model.compute_forward_dynamics(q=..., qd=..., f=...)
```

```sh
Traceback (most recent call last):
...
  File "/home/soraxas/${SOME_PATH}/site-packages/differentiable_robot_model/spatial_vector_algebra.py", line 331, in multiply_motion_vec
    mcom = com * mass
TypeError: unsupported operand type(s) for *: 'NoneType' and 'NoneType'
```

### With blacklist

Running the code with the added blacklist

```python
robot_model = DifferentiableRobotModel(urdf_path, "jaco",
	links_blacklist={'world', 'j2n6s300_end_effector'},
	device=device
)
```

it works as expected in the `robot_model.compute_forward_dynamics(...)` function and other related methods.

I've also added the corresponding pytest to check for the warning message correctly emitting and the blacklist avoiding the crash.
