### PR TITLE
Debug batched forward dynamics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
       - run:
           name: Run black formatting
           command: |
-            pip install black
+            pip install black==22.1.0
             black --check --exclude "docs" .
 
 workflows:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 22.1.0
     hooks:
       - id: black
         exclude: docs

--- a/differentiable_robot_model/rigid_body.py
+++ b/differentiable_robot_model/rigid_body.py
@@ -84,7 +84,9 @@ class DifferentiableRigidBody(torch.nn.Module):
         fixed_rotation = (z_rot(yaw) @ y_rot(pitch)) @ x_rot(roll)
 
         # when we update the joint angle, we also need to update the transformation
-        self.joint_pose.set_translation(torch.reshape(self.trans(), (1, 3)))
+        self.joint_pose.set_translation(
+            torch.reshape(self.trans(), (1, 3)).repeat(batch_size, 1)
+        )
         if torch.abs(self.joint_axis[0, 0]) == 1:
             rot = x_rot(torch.sign(self.joint_axis[0, 0]) * q)
         elif torch.abs(self.joint_axis[0, 1]) == 1:

--- a/differentiable_robot_model/se3_so3_util.py
+++ b/differentiable_robot_model/se3_so3_util.py
@@ -201,7 +201,7 @@ def logMapSE3(T, epsilon=1.0e-14):
                     (2.0 * torch.sin(norm_omega))
                     - (norm_omega * (1.0 + torch.cos(norm_omega)))
                 )
-                / ((2 * (norm_omega ** 2) * torch.sin(norm_omega)) + epsilon)
+                / ((2 * (norm_omega**2) * torch.sin(norm_omega)) + epsilon)
             )
             * torch.matmul(omegahat, omegahat)
         )

--- a/differentiable_robot_model/spatial_vector_algebra.py
+++ b/differentiable_robot_model/spatial_vector_algebra.py
@@ -248,7 +248,6 @@ class SpatialMotionVec(object):
         tmp1 = torch.sum(self.ang * smv.ang, dim=-1)
         tmp2 = torch.sum(self.lin * smv.lin, dim=-1)
         return tmp1 + tmp2
-        # return self.ang[0].dot(smv.ang[0]) + self.lin[0].dot(smv.lin[0])
 
 
 class SpatialForceVec(object):
@@ -301,14 +300,8 @@ class SpatialForceVec(object):
         )
 
     def dot(self, smv):
-        # return self.ang[0].dot(smv.ang[0]) + self.lin[0].dot(smv.lin[0])
-        batch_size, n_d = self.ang.shape
-        tmp1 = torch.bmm(
-            self.ang.view(batch_size, 1, n_d), smv.ang.view(batch_size, n_d, 1)
-        ).squeeze()
-        tmp2 = torch.bmm(
-            self.lin.view(batch_size, 1, n_d), smv.lin.view(batch_size, n_d, 1)
-        ).squeeze()
+        tmp1 = torch.sum(self.ang * smv.ang, dim=-1)
+        tmp2 = torch.sum(self.lin * smv.lin, dim=-1)
         return tmp1 + tmp2
 
 

--- a/tests/test_kinematics_dynamics.py
+++ b/tests/test_kinematics_dynamics.py
@@ -45,7 +45,9 @@ test_data = [
 batch_shapes = [
     tuple(),
     (1,),
-    (3,),
+    (3,),  # same dim size as so3 variables
+    (6,),  # same dim size as se3 variables
+    (7,),  # same dim size as 7dof robot states
 ]
 
 ################

--- a/tests/test_kinematics_dynamics.py
+++ b/tests/test_kinematics_dynamics.py
@@ -42,6 +42,7 @@ test_data = [
     ("kinova_description/urdf/jaco_clean.urdf", [(8, "j2n6s300_link_ee")]),
 ]
 
+# Note: test batch sizes that coincide with other data dims to ensure errors don't occur during reshaping ops
 batch_shapes = [
     tuple(),
     (1,),


### PR DESCRIPTION
- Fix matrix multiplications in multiple places to work with general batched inputs.
- Fix wrong assumption where body inertia (`IA`) is constant across batch (not constant when backpropagating equivalent inertia across links).
- Switch `robot_model.forward_dynamics` to use the new, now debugged implementation.