### PR TITLE
Fix version name collision when uploading to TestPyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,11 @@ latest_tag = (
     .strip("\n")
 )
 version_num = latest_tag.strip("v")
+branch_name = (
+    subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+    .decode("utf-8")
+    .strip("\n")
+)
 rev_num = (
     subprocess.check_output(["git", "rev-list", f"{latest_tag}..HEAD", "--count"])
     .decode("utf-8")
@@ -37,7 +42,7 @@ rev_num = (
 )
 VERSION = version_num
 if int(rev_num) > 0:
-    VERSION = f"{version_num}-{rev_num}"
+    VERSION = f"{version_num}-{branch_name}..{rev_num}"
 
 # resource files
 data_files = []

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ branch_name = (
     .decode("utf-8")
     .strip("\n")
 )
-branch_hash = abs(hash(branch_name)) % (10**8)
+branch_hash = abs(hash(branch_name)) % (10**4)
 
 rev_num = (
     subprocess.check_output(["git", "rev-list", f"{latest_tag}..HEAD", "--count"])
@@ -46,7 +46,7 @@ rev_num = (
 
 VERSION = version_num
 if int(rev_num) > 0:
-    VERSION = f"{version_num}-{branch_hash}..{rev_num}"
+    VERSION = f"{version_num}a{rev_num}.dev{branch_hash}"
 
 # resource files
 data_files = []

--- a/setup.py
+++ b/setup.py
@@ -30,19 +30,23 @@ latest_tag = (
     .strip("\n")
 )
 version_num = latest_tag.strip("v")
+
 branch_name = (
     subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
     .decode("utf-8")
     .strip("\n")
 )
+branch_hash = abs(hash(branch_name)) % (10**8)
+
 rev_num = (
     subprocess.check_output(["git", "rev-list", f"{latest_tag}..HEAD", "--count"])
     .decode("utf-8")
     .strip("\n")
 )
+
 VERSION = version_num
 if int(rev_num) > 0:
-    VERSION = f"{version_num}-{branch_name}..{rev_num}"
+    VERSION = f"{version_num}-{branch_hash}..{rev_num}"
 
 # resource files
 data_files = []


### PR DESCRIPTION
Previous version names were determined by the number of commits after the previous tag, which would cause name collisions between different branches.
Added hash of the branch name to the temporary version to avoid this issue.